### PR TITLE
fix required write permissions on reading from a jar

### DIFF
--- a/modules/core/jvm/src/main/scala/dumbo/internal/FileSystemPlatform.scala
+++ b/modules/core/jvm/src/main/scala/dumbo/internal/FileSystemPlatform.scala
@@ -4,65 +4,32 @@
 
 package dumbo.internal
 
-import java.net.{URI, URL}
-import java.nio.file.{FileSystem, FileSystems, Files, Paths as JPaths}
+import java.nio.file.Paths as JPaths
 
-import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
 import cats.effect.{Resource, Sync}
-import fs2.Stream
-import fs2.io.file.{Files as Fs2Files, Flags, Path}
+import fs2.io.file.{Files as Fs2Files, Path}
 
 private[dumbo] class MultipleResoucesException(message: String) extends Throwable(message)
 
 private[dumbo] trait FileSystemPlatform {
-
-  private def jarFs[F[_]: Sync: Fs2Files](sourceUrl: URL): Resource[F, FsPlatform[F]] = for {
-    srcUri <- Resource.eval(Sync[F].delay(sourceUrl.toURI()))
-    fs <- Resource
-            .fromAutoCloseable[F, FileSystem]({
-              Sync[F].delay {
-                FileSystems.newFileSystem(srcUri, new java.util.HashMap[String, Object]())
-              }
-            })
-  } yield new FsPlatform[F] {
-    override val sourcesUri: URI = srcUri
-    override def list(path: Path): Stream[F, Path] =
-      Stream
-        .fromIterator(Files.list(fs.getPath(path.toNioPath.toString())).iterator().asScala, 16)
-        .map(Path.fromNioPath(_))
-
-    override def readUtf8Lines(path: Path): Stream[F, String] =
-      Fs2Files[F].readUtf8Lines(fs2.io.file.Path.fromFsPath(fs, path.toString))
-
-    override def readUtf8(path: Path): Stream[F, String] =
-      Fs2Files[F]
-        .readAll(fs2.io.file.Path.fromFsPath(fs, path.toString), 64 * 2048, Flags.Read)
-        .through(fs2.text.utf8.decode)
-
-    override def getLastModifiedTime(path: Path): F[FiniteDuration] =
-      Fs2Files[F].getLastModifiedTime(fs2.io.file.Path.fromFsPath(fs, path.toString))
-  }
 
   def forDir[F[_]: Sync: Fs2Files](sourceDir: Path): Resource[F, FsPlatform[F]] =
     for {
       resouceUrls <- Resource
                        .eval(
                          Sync[F].delay {
-                           getClass().getClassLoader().getResources(sourceDir.toString).asScala.toList
+                           getClass().getClassLoader().getResources(sourceDir.toString).asScala.toList.map(_.toURI())
                          }
                        )
       fs <- resouceUrls match {
-              case Nil                                       => FsPlatform.fileFs(sourceDir = sourceDir)
-              case u :: Nil if u.toString.startsWith("jar:") => jarFs(u)
-              case u :: Nil =>
-                val baseDir =
-                  Try(u.toURI()).toOption.map { uri =>
-                    // given absolutePath = /a/b/c/d and sourceDir = c/d return /a/b as baseDir
-                    Path(JPaths.get(uri).toString().stripSuffix(sourceDir.toString))
-                  }
+              case Nil                                           => FsPlatform.fileFs(sourceDir = sourceDir)
+              case uri :: Nil if uri.toString.startsWith("jar:") => FsPlatform.jarFs(uri, sourceDir)
+              case uri :: Nil                                    =>
+                // given absolutePath = /a/b/c/d and sourceDir = c/d return /a/b as baseDir
+                val baseDir = Try(Path(JPaths.get(uri).toString().stripSuffix(sourceDir.toString))).toOption
                 FsPlatform.fileFs(sourceDir = sourceDir, baseDir = baseDir)
               case multiple =>
                 Resource.raiseError(

--- a/modules/core/shared/src/main/scala/dumbo/internal/FsPlatform.scala
+++ b/modules/core/shared/src/main/scala/dumbo/internal/FsPlatform.scala
@@ -5,10 +5,12 @@
 package dumbo.internal
 
 import java.net.URI
+import java.util.zip.ZipFile
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{FiniteDuration, *}
+import scala.jdk.CollectionConverters.*
 
-import cats.effect.Resource
+import cats.effect.{Resource, Sync}
 import fs2.Stream
 import fs2.io.file.{Files as Fs2Files, Flags, Path}
 
@@ -45,4 +47,38 @@ private[dumbo] object FsPlatform extends FileSystemPlatform {
           Fs2Files[F].getLastModifiedTime(absolutePath(path))
       }
     }
+
+  def jarFs[F[_]: Sync](jarUri: URI, sourceDir: Path): Resource[F, FsPlatform[F]] = Resource.fromAutoCloseable {
+    Sync[F].delay {
+      val srcUriStr   = jarUri.toString()
+      val jarFilePath = srcUriStr.slice(srcUriStr.lastIndexOf(":") + 1, srcUriStr.lastIndexOf("!"))
+      new ZipFile(jarFilePath)
+    }
+  }.map { fs =>
+    new FsPlatform[F] {
+      override val sourcesUri: URI = jarUri
+      override def list(path: Path): Stream[F, Path] =
+        Stream
+          .fromIterator(
+            fs.entries()
+              .asScala
+              .filter(_.getName().startsWith(sourceDir.toString))
+              .map(f => Path(f.getName())),
+            64,
+          )
+
+      override def readUtf8Lines(path: Path): Stream[F, String] =
+        readUtf8(path).through(fs2.text.lines)
+
+      override def readUtf8(path: Path): Stream[F, String] =
+        fs2.io
+          .readInputStream(Sync[F].delay(fs.getInputStream(fs.getEntry(path.toString))), 64 * 2048, false)
+          .through(fs2.text.utf8.decode)
+
+      override def getLastModifiedTime(path: Path): F[FiniteDuration] =
+        Sync[F].delay {
+          fs.getEntry(path.toString).getLastModifiedTime.toMillis().millis
+        }
+    }
+  }
 }

--- a/modules/core/shared/src/main/scala/dumbo/internal/FsPlatform.scala
+++ b/modules/core/shared/src/main/scala/dumbo/internal/FsPlatform.scala
@@ -63,7 +63,7 @@ private[dumbo] object FsPlatform extends FileSystemPlatform {
             fs.entries()
               .asScala
               .filter(_.getName().startsWith(sourceDir.toString))
-              .map(f => Path(f.getName())),
+              .map(entry => Path(entry.getName())),
             64,
           )
 
@@ -72,7 +72,11 @@ private[dumbo] object FsPlatform extends FileSystemPlatform {
 
       override def readUtf8(path: Path): Stream[F, String] =
         fs2.io
-          .readInputStream(Sync[F].delay(fs.getInputStream(fs.getEntry(path.toString))), 64 * 2048, false)
+          .readInputStream(
+            Sync[F].delay(fs.getInputStream(fs.getEntry(path.toString))),
+            64 * 2048,
+            closeAfterUse = true,
+          )
           .through(fs2.text.utf8.decode)
 
       override def getLastModifiedTime(path: Path): F[FiniteDuration] =


### PR DESCRIPTION
Fixes requirement for write permission on reading resources from a jar.
```
java.nio.file.AccessDeniedException: /opt/docker/lib/zipfstmp1089021794092641043.tmp

at java.base/sun.nio.fs.UnixException.translateToIOException(Unknown Source)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(Unknown Source)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(Unknown Source)
        at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(Unknown Source)
        at java.base/java.nio.file.Files.newByteChannel(Unknown Source)
        at java.base/java.nio.file.Files.createFile(Unknown Source)
        at java.base/java.nio.file.TempFileHelper.create(Unknown Source)
        at java.base/java.nio.file.TempFileHelper.createTempFile(Unknown Source)
        at java.base/java.nio.file.Files.createTempFile(Unknown Source)
        at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.createTempFileInSameDirectoryAs(Unknown Source)
        at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.getTempPathForEntry(Unknown Source)
        at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.newFileChannel(Unknown Source)
        at jdk.zipfs/jdk.nio.zipfs.ZipPath.newFileChannel(Unknown Source)
        at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.newFileChannel(Unknown Source)
        at java.base/java.nio.channels.FileChannel.open(Unknown Source)
        at java.base/java.nio.channels.FileChannel.open(Unknown Source)
        at fs2.io.file.FilesCompanionPlatform$AsyncFiles.$anonfun$open$1(FilesPlatform.scala:316)
       // ...
```