### PR TITLE
add location info to log (Scala 2 JVM), fix cli binary release step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,7 @@ jobs:
         run: sbt tlCiRelease
 
       - name: Upload release binaries
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           files: modules/cli/native/target/bin/*

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ ThisBuild / githubWorkflowPublish += WorkflowStep.Use(
   params = Map(
     "files" -> "modules/cli/native/target/bin/*"
   ),
-  cond = None,
+  cond = Some("startsWith(github.ref, 'refs/tags/')"),
 )
 
 ThisBuild / githubWorkflowBuild += WorkflowStep.Sbt(

--- a/modules/core/jvm/src/main/scala-2/dumbo/internal/DumboPlatform.scala
+++ b/modules/core/jvm/src/main/scala-2/dumbo/internal/DumboPlatform.scala
@@ -8,8 +8,11 @@ import cats.effect.Sync
 import dumbo.{DumboWithResourcesPartiallyApplied, ResourceFilePath}
 
 private[dumbo] trait DumboPlatform {
-  def withResourcesIn[F[_]: Sync](location: String): DumboWithResourcesPartiallyApplied[F] =
+  def withResourcesIn[F[_]: Sync](location: String): DumboWithResourcesPartiallyApplied[F] = {
+    val (locationInfo, resources) = ResourceFilePath.fromResourcesDir(location)
+
     new DumboWithResourcesPartiallyApplied[F](
-      ResourceReader.embeddedResources(ResourceFilePath.fromResourcesDir(location))
+      ResourceReader.embeddedResources(resources, Some(locationInfo))
     )
+  }
 }

--- a/modules/core/shared/src/main/scala/dumbo/internal/ResourcesReader.scala
+++ b/modules/core/shared/src/main/scala/dumbo/internal/ResourcesReader.scala
@@ -43,9 +43,12 @@ private[dumbo] object ResourceReader {
     }
   }
 
-  def embeddedResources[F[_]: Sync](readResources: F[List[ResourceFilePath]]): ResourceReader[F] =
+  def embeddedResources[F[_]: Sync](
+    readResources: F[List[ResourceFilePath]],
+    locationInfo: Option[String] = None,
+  ): ResourceReader[F] =
     new ResourceReader[F] {
-      override val location: Option[String] = None
+      override val location: Option[String] = locationInfo
 
       override def list: Stream[F, Path] = Stream.evals(readResources).map(r => Path.fromNioPath(r.toNioPath))
 


### PR DESCRIPTION
- add location info to log when listing resource files at runtime (Scala 2 / JVM)
- fix cli binary release step in ci