### PR TITLE
fix resource file pattern match

### DIFF
--- a/modules/core/shared/src/main/scala/dumbo/ResourceFile.scala
+++ b/modules/core/shared/src/main/scala/dumbo/ResourceFile.scala
@@ -93,7 +93,7 @@ final case class ResourceFileDescription(
 object ResourceFileDescription {
   def fromNioPath(p: JPath): Either[String, ResourceFileDescription] = fromFilePath(Path.fromNioPath(p))
   def fromFilePath(p: Path): Either[String, ResourceFileDescription] = {
-    val pattern = "^V(.+)__(.+)\\.sql$".r
+    val pattern = "^V([^_]+)__(.+)\\.sql$".r
 
     p.fileName.toString match {
       case pattern(version, name) =>

--- a/modules/tests/shared/src/test/scala/ResourceFileDescriptionSpec.scala
+++ b/modules/tests/shared/src/test/scala/ResourceFileDescriptionSpec.scala
@@ -13,6 +13,8 @@ class ResourceFileDescriptionSpec extends ffstest.FTest {
       "V-003__test.sql",
       "V002__test.sql",
       "V1__test.sql",
+      "V3__V4__test.sql",
+      "V3.2____V4____test.sql",
       "V5.2__test.sql",
       "V-1.2__test.sql",
       "V1.2.3.4.5.6.7.8.9__test.sql",
@@ -22,11 +24,11 @@ class ResourceFileDescriptionSpec extends ffstest.FTest {
       "V2013.01.15.11.35.56__test.sql",
     )
 
-    val versions = fileNames
+    val (failures, versions) = fileNames
       .map(s => ResourceFileDescription.fromFilePath(Path(s)))
-      .collect { case Right(r) => r }
-      .sorted
-      .map(_.version)
+      .partitionMap(r => r)
+
+    assertEquals(failures, Nil)
 
     val expected = List(
       ResourceFileVersion("-003", NonEmptyList.of(-3L)),
@@ -34,6 +36,8 @@ class ResourceFileDescriptionSpec extends ffstest.FTest {
       ResourceFileVersion("1", NonEmptyList.of(1L)),
       ResourceFileVersion("1.2.3.4.5.6.7.8.9", NonEmptyList.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L)),
       ResourceFileVersion("002", NonEmptyList.of(2L)),
+      ResourceFileVersion("3", NonEmptyList.of(3L)),
+      ResourceFileVersion("3.2", NonEmptyList.of(3L, 2L)),
       ResourceFileVersion("5.2", NonEmptyList.of(5L, 2L)),
       ResourceFileVersion("205.68", NonEmptyList.of(205L, 68L)),
       ResourceFileVersion("2013.01.15.11.35.56", NonEmptyList.of(2013L, 1L, 15L, 11L, 35L, 56L)),
@@ -41,7 +45,7 @@ class ResourceFileDescriptionSpec extends ffstest.FTest {
       ResourceFileVersion("20130115113556", NonEmptyList.of(20130115113556L)),
     )
 
-    assertEquals(versions, expected)
+    assertEquals(versions.sorted.map(_.version), expected)
   }
 
   test("distinct by version") {

--- a/modules/tests/shared/src/test/scala/ResourceFileDescriptionSpec.scala
+++ b/modules/tests/shared/src/test/scala/ResourceFileDescriptionSpec.scala
@@ -24,9 +24,8 @@ class ResourceFileDescriptionSpec extends ffstest.FTest {
       "V2013.01.15.11.35.56__test.sql",
     )
 
-    val (failures, versions) = fileNames
-      .map(s => ResourceFileDescription.fromFilePath(Path(s)))
-      .partitionMap(r => r)
+    val results              = fileNames.map(s => ResourceFileDescription.fromFilePath(Path(s)))
+    val (failures, versions) = (results.collect { case Left(e) => e }, results.collect { case Right(v) => v })
 
     assertEquals(failures, Nil)
 


### PR DESCRIPTION
backport of https://github.com/rolang/dumbo/pull/25 for `0.0.x` release