### PR TITLE
Update to skunk 1.0.0-M10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -237,7 +237,7 @@ lazy val root = tlCrossRootProject
   .aggregate(core, tests, testsFlyway, example)
   .settings(commonSettings)
 
-lazy val skunkVersion = "1.0.0-M9"
+lazy val skunkVersion = "1.0.0-M10"
 
 lazy val epollcatVersion = "0.1.6"
 


### PR DESCRIPTION
M9 is broken: https://github.com/typelevel/skunk/releases/tag/v1.0.0-M9