### PR TITLE
Update skunk to 1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,5 +385,5 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: sample-lib_3 dumbo_3 dumbo_2.13 testsflyway_3 testsflyway_2.13 dumbo_3 dumbo_2.13 dumbo_3 dumbo_2.13 tests_3 tests_2.13 example_3 sample-lib-test_3 tests_native0.4_3 tests_native0.4_2.13
+          modules-ignore: sample-lib_3 dumbo_3 dumbo_2.13 testsflyway_3 testsflyway_2.13 dumbo_3 dumbo_2.13 dumbo_3 dumbo_2.13 tests_3 tests_2.13 example_3 sample-lib-test_3 tests_native0.5_3 tests_native0.5_2.13
           configs-ignore: test scala-tool scala-doc-tool test-internal

--- a/build.sbt
+++ b/build.sbt
@@ -247,11 +247,11 @@ lazy val root = tlCrossRootProject
   .aggregate(core, tests, testsFlyway)
   .settings(commonSettings)
 
-lazy val skunkVersion = "1.0.0-M12"
+lazy val skunkVersion = "1.0.0"
 
-lazy val munitVersion = "1.0.0"
+lazy val munitVersion = "1.2.0"
 
-lazy val munitCEVersion = "2.1.0"
+lazy val munitCEVersion = "2.2.0"
 
 lazy val core = crossProject(JVMPlatform, NativePlatform)
   .crossType(CrossType.Full)
@@ -356,7 +356,7 @@ lazy val tests = crossProject(JVMPlatform, NativePlatform)
     },
   )
 
-lazy val flywayVersion     = "11.0.0"
+lazy val flywayVersion     = "12.4.0"
 lazy val postgresqlVersion = "42.7.10"
 lazy val testsFlyway       = project
   .in(file("modules/tests-flyway"))
@@ -386,8 +386,8 @@ lazy val example = project
     Compile / headerCheck := Nil,
     scalacOptions -= "-Werror",
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "log4cats-slf4j"  % "2.7.1",
-      "ch.qos.logback" % "logback-classic" % "1.5.18",
+      "org.typelevel" %% "log4cats-slf4j"  % "2.8.0",
+      "ch.qos.logback" % "logback-classic" % "1.5.32",
     ),
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val `scala-2.13`     = "2.13.18"
 lazy val `scala-3`        = "3.3.7"
 lazy val `scala-3-latest` = "3.7.4"
 
-ThisBuild / tlBaseVersion      := "0.8"
+ThisBuild / tlBaseVersion      := "0.9"
 ThisBuild / startYear          := Some(2023)
 ThisBuild / scalaVersion       := `scala-3`
 ThisBuild / crossScalaVersions := Seq(`scala-3`, `scala-2.13`)

--- a/modules/cli/shared/src/main/scala/dumbo/cli/Dumbo.scala
+++ b/modules/cli/shared/src/main/scala/dumbo/cli/Dumbo.scala
@@ -14,7 +14,7 @@ import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 import dumbo.logging.Implicits.consolePrettyWithTimestamp
 
 object Dumbo extends IOApp {
-  implicit val noopMeter: Meter[IO] = Meter.noop[IO]
+  given Meter[IO] = Meter.noop[IO]
 
   private def printHelp(cmd: Option[Command] = None) = {
     val tab = "    "

--- a/modules/cli/shared/src/main/scala/dumbo/cli/Dumbo.scala
+++ b/modules/cli/shared/src/main/scala/dumbo/cli/Dumbo.scala
@@ -9,10 +9,13 @@ import cats.effect.std.Console
 import cats.effect.{ExitCode, IO, IOApp}
 import dumbo.BuildInfo
 import dumbo.Dumbo.defaults
+import org.typelevel.otel4s.metrics.Meter
 import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 import dumbo.logging.Implicits.consolePrettyWithTimestamp
 
 object Dumbo extends IOApp {
+  implicit val noopMeter: Meter[IO] = Meter.noop[IO]
+
   private def printHelp(cmd: Option[Command] = None) = {
     val tab = "    "
 

--- a/modules/core/shared/src/main/scala/dumbo/Dumbo.scala
+++ b/modules/core/shared/src/main/scala/dumbo/Dumbo.scala
@@ -21,6 +21,7 @@ import dumbo.logging.Logger
 import fs2.Stream
 import fs2.io.file.*
 import fs2.io.net.Network
+import org.typelevel.otel4s.metrics.Meter
 import org.typelevel.otel4s.trace.Tracer
 import skunk.*
 import skunk.Session.Credentials
@@ -37,7 +38,15 @@ final class DumboWithResourcesPartiallyApplied[F[_]](reader: ResourceReader[F]) 
     schemaHistoryTable: String = Dumbo.defaults.schemaHistoryTable,
     validateOnMigrate: Boolean = Dumbo.defaults.validateOnMigrate,
     cleanDisabled: Boolean = Dumbo.defaults.cleanDisabled,
-  )(implicit S: Sync[F], T: Temporal[F], L: Logger[F], C: Console[F], TRC: Tracer[F], N: Network[F]): Dumbo[F] =
+  )(implicit
+    S: Sync[F],
+    T: Temporal[F],
+    L: Logger[F],
+    C: Console[F],
+    TRC: Tracer[F],
+    MTR: Meter[F],
+    N: Network[F],
+  ): Dumbo[F] =
     withSession(
       sessionResource = toSessionResource(connection, defaultSchema, schemas),
       defaultSchema = defaultSchema,
@@ -72,7 +81,7 @@ final class DumboWithResourcesPartiallyApplied[F[_]](reader: ResourceReader[F]) 
     schemaHistoryTable: String = Dumbo.defaults.schemaHistoryTable,
     validateOnMigrate: Boolean = Dumbo.defaults.validateOnMigrate,
     cleanDisabled: Boolean = Dumbo.defaults.cleanDisabled,
-  )(implicit A: Async[F], L: Logger[F], LIO: LiftIO[F], C: Console[F], TRC: Tracer[F]): Dumbo[F] = {
+  )(implicit A: Async[F], L: Logger[F], LIO: LiftIO[F], C: Console[F], TRC: Tracer[F], MTR: Meter[F]): Dumbo[F] = {
     implicit val network: Network[F] = Network.forLiftIO[F]
     val sessionResource              = toSessionResource(connection, defaultSchema, schemas)
 
@@ -154,7 +163,7 @@ final class DumboWithResourcesPartiallyApplied[F[_]](reader: ResourceReader[F]) 
     connection: ConnectionConfig,
     defaultSchema: String,
     schemas: Set[String],
-  )(implicit T: Temporal[F], C: Console[F], TRC: Tracer[F], N: Network[F]) = {
+  )(implicit T: Temporal[F], C: Console[F], TRC: Tracer[F], MTR: Meter[F], N: Network[F]) = {
     val searchPath = Dumbo.toSearchPath(defaultSchema, schemas)
     val params     = Session.DefaultConnectionParameters ++ Map("search_path" -> searchPath)
 

--- a/modules/example/src/main/scala/ExampleApp.scala
+++ b/modules/example/src/main/scala/ExampleApp.scala
@@ -5,9 +5,12 @@
 import cats.effect.{IO, IOApp}
 import dumbo.logging.Implicits.console
 import dumbo.{ConnectionConfig, Dumbo}
+import org.typelevel.otel4s.metrics.Meter
 import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 
 object ExampleApp extends IOApp.Simple:
+  given Meter[IO] = Meter.noop[IO]
+
   def run = Dumbo
     .withResourcesIn[IO]("db/migration")
     .apply(

--- a/modules/example/src/main/scala/ExampleLog4Cats.scala
+++ b/modules/example/src/main/scala/ExampleLog4Cats.scala
@@ -1,9 +1,12 @@
 import cats.effect.{IO, IOApp}
 import dumbo.{ConnectionConfig, Dumbo}
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.otel4s.metrics.Meter
 import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 
 object ExampleLog4Cats extends IOApp.Simple:
+  given Meter[IO] = Meter.noop[IO]
+
   def run =
     Slf4jLogger
       .create[IO]

--- a/modules/tests/shared/src/main/scala/ffstest/FFramework.scala
+++ b/modules/tests/shared/src/main/scala/ffstest/FFramework.scala
@@ -17,13 +17,15 @@ import dumbo.exception.DumboValidationException
 import dumbo.logging.{LogLevel, Logger}
 import dumbo.{ConnectionConfig, Dumbo, DumboWithResourcesPartiallyApplied, History, HistoryEntry}
 import munit.CatsEffectSuite
+import org.typelevel.otel4s.metrics.Meter
 import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 import skunk.Session
 import skunk.Session.Credentials
 import skunk.implicits.*
 
 trait FTest extends CatsEffectSuite with FTestPlatform {
-  def postgresPort: Int = 5432
+  implicit val noopMeter: Meter[IO] = Meter.noop[IO]
+  def postgresPort: Int             = 5432
 
   def dbTest(name: String)(f: => IO[Unit]): Unit = test(name)(dropSchemas >> f)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.0")
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.11")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 


### PR DESCRIPTION
## Summary
- Bump skunk to 1.0.0 (final) and sbt-scala-native to 0.5.11 (skunk 1.0.0 is only published for Scala Native 0.5)
- Thread a `Meter[F]` implicit through `Dumbo` alongside the existing `Tracer[F]` — required by `Session.Builder` in skunk 1.0.0
- Wire up no-op `Meter` instances in the CLI, examples and test framework
- Bump related deps: munit 1.2.0, munit-cats-effect 2.2.0, flyway 12.4.0, log4cats-slf4j 2.8.0, logback 1.5.32, sbt-scalafmt 2.6.0

Supersedes the open #217 which had the same skunk/sbt-scala-native bumps but didn't propagate the `Meter` implicit to the CLI, examples and test suite.

## Test plan
- [x] `sbt check` passes (scalafix + scalafmt)
- [x] Cross-compile on Scala 3.3.7 and 2.13.18 (JVM + Native 0.5) for `core`, `tests`, `tests-flyway`, `cli`, `example`
- [ ] `sbt test` against postgres (docker-compose) — not run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)