### PR TITLE
Disable CockroachDB tests on Scala Native in CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -362,6 +362,10 @@ lazy val tests = crossProject(JVMPlatform, NativePlatform)
     crossScalaVersions := Seq(`scala-3`),
     Test / nativeBrewFormulas ++= brewFormulas,
     Test / envVars ++= Map("S2N_DONT_MLOCK" -> "1"),
+    Test / testOptions ++= {
+      if (sys.env.contains("CI")) Seq(Tests.Argument(TestFrameworks.MUnit, "--exclude-tags=CockroachDbTest"))
+      else Seq.empty
+    },
     nativeConfig ~= {
       _.withEmbedResources(true)
     },

--- a/modules/tests/shared/src/test/scala/DumboMigrationSpec.scala
+++ b/modules/tests/shared/src/test/scala/DumboMigrationSpec.scala
@@ -13,6 +13,7 @@ import dumbo.Dumbo.LockSupport
 import dumbo.logging.Implicits.consolePrettyWithTimestamp
 import dumbo.logging.LogLevel
 import ffstest.TestLogger
+import munit.Tag
 import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 import skunk.codec.all.*
 import skunk.implicits.*
@@ -27,8 +28,8 @@ trait DumboMigrationSpec extends ffstest.FTest {
     assertEquals(histA.map(toCompare), histB.map(toCompare))
   }
 
-  test("Execute multiple migrations in parallel") {
-    dropSchemas >> (1 to 5).toList.traverse_ { _ =>
+  dbTest("Execute multiple migrations in parallel") {
+    (1 to 5).toList.traverse_ { _ =>
       val schema        = someSchemaName
       val withResources = dumboWithResources("db/test_1")
 
@@ -380,7 +381,14 @@ class DumboSpecPostgres11 extends DumboMigrationSpec {
   override val postgresPort: Int = 5434
 }
 
+object TestTags {
+  val CockroachDbTest: Tag = new Tag("CockroachDbTest")
+}
+
 class DumboSpecCockroachDb extends DumboMigrationSpec {
   override val db: Db            = Db.CockroachDb
   override val postgresPort: Int = 5436
+
+  override def dbTest(name: String)(f: => IO[Unit]): Unit =
+    test(name.tag(TestTags.CockroachDbTest))(dropSchemas >> f)
 }


### PR DESCRIPTION
## Summary

CockroachDB tests (`DumboSpecCockroachDb`) currently run on both JVM and Native platforms in CI. They are often slower and less relevant on Native, and CockroachDB differs from Postgres in ways that make some tests less useful for the Native target.

Changes:
- Introduced a `CockroachDbTest` MUnit tag
- Overrode `dbTest` in `DumboSpecCockroachDb` to tag all its tests with `CockroachDbTest`
- In `build.sbt`, added `--exclude-tags=CockroachDbTest` to native test options when `CI` env var is set — so the exclusion only applies in CI, not locally
- Converted the lone `test(...)` call to `dbTest(...)` for consistency

## Test plan

1. `sbt testsNative/Test/compile` — compiles cleanly
2. `sbt testsJVM/Test/compile` — compiles cleanly on Scala 3 and 2.13
3. Locally (no `CI` env var): `DumboSpecCockroachDb` tests run as before
4. In CI on `rootNative`: tests tagged `CockroachDbTest` are excluded via MUnit `--exclude-tags`