### PR TITLE
Migrate build from sbt 1.12.12 to sbt 2.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,228 +1,33 @@
+import sbt.{given, *}
 import scala.scalanative.build.*
 
 lazy val `scala-2.13`     = "2.13.18"
 lazy val `scala-3`        = "3.3.8"
 lazy val `scala-3-latest` = "3.7.4"
 
-ThisBuild / tlBaseVersion      := "0.10"
-ThisBuild / startYear          := Some(2023)
-ThisBuild / scalaVersion       := `scala-3`
-ThisBuild / crossScalaVersions := Seq(`scala-3`, `scala-2.13`)
-ThisBuild / tlJdkRelease       := Some(17)
+startYear          := Some(2023)
+scalaVersion       := `scala-3`
+crossScalaVersions := Seq(`scala-3`, `scala-2.13`)
 
-ThisBuild / organization := "dev.rolang"
-ThisBuild / licenses     := Seq(License.MIT)
-ThisBuild / developers   := List(
+organization := "dev.rolang"
+licenses     := Seq(License.MIT)
+developers   := List(
   Developer(id = "rolang", name = "Roman Langolf", email = "rolang@pm.me", url = url("https://rolang.dev"))
 )
-ThisBuild / evictionWarningOptions ~= (_.withConfigurations(List(Compile)))
-ThisBuild / versionScheme := Some("early-semver")
-ThisBuild / description   := "Simple database migration tool for Scala + Postgres"
-ThisBuild / homepage      := Some(url("https://github.com/rolang/dumbo"))
+evictionWarningOptions ~= (_.withConfigurations(List(Compile)))
+versionScheme := Some("early-semver")
+description   := "Simple database migration tool for Scala + Postgres"
+homepage      := Some(uri("https://github.com/rolang/dumbo"))
 
-ThisBuild / semanticdbEnabled := true
-ThisBuild / semanticdbVersion := scalafixSemanticdb.revision // use Scalafix compatible version
-
-// githubWorkflow
-val defautOs   = "ubuntu-latest"
-val linuxOsArm = "ubuntu-24.04-arm"
-
-val macOs = "macos-latest"
-
-val defaultJavaVersion = JavaSpec.temurin("25")
-val testJavaVersions   = Seq(defaultJavaVersion, JavaSpec.temurin("17"))
-
-val actionGhReleaseVersion        = "v2" // https://github.com/softprops/action-gh-release
-val actionUploadArtifactVersion   = "v7" // https://github.com/actions/upload-artifact
-val actionDownloadArtifactVersion = "v8" // https://github.com/actions/download-artifact
-
-ThisBuild / githubWorkflowOSes := Seq(defautOs, linuxOsArm, macOs)
-ThisBuild / githubWorkflowBuildMatrixExclusions ++= Seq(
-  MatrixExclude(Map("os" -> linuxOsArm, "project" -> "rootJVM")),
-  MatrixExclude(Map("scala" -> "2.13", "project" -> "rootNative")),
-  MatrixExclude(Map("os" -> macOs, "project" -> "rootJVM")),
-)
-ThisBuild / githubWorkflowJavaVersions := testJavaVersions
-ThisBuild / tlCiHeaderCheck            := true
-ThisBuild / tlCiScalafixCheck          := false
-
-lazy val llvmVersion  = "22"
-lazy val brewFormulas = Set("s2n", "utf8proc")
-lazy val isTagCond    = "startsWith(github.ref, 'refs/tags/')"
-
-ThisBuild / githubWorkflowBuildPreamble ++= Seq(
-  WorkflowStep.Run(
-    commands = List(
-      "/home/linuxbrew/.linuxbrew/bin/brew update",
-      s"/home/linuxbrew/.linuxbrew/bin/brew install llvm@$llvmVersion ${brewFormulas.mkString(" ")}",
-      s"""echo "LLVM_BIN=/home/linuxbrew/.linuxbrew/opt/llvm@$llvmVersion/bin" >> $$GITHUB_ENV""",
-    ),
-    cond = Some("(matrix.project == 'rootNative') && startsWith(matrix.os, 'ubuntu')"),
-    name = Some("Install native dependencies (ubuntu)"),
-  )
-)
-ThisBuild / githubWorkflowBuildPreamble ++= List(
-  macOs -> "/opt/homebrew/opt"
-).map { case (os, llvmBase) =>
-  WorkflowStep.Run(
-    commands = List(
-      s"brew install llvm@$llvmVersion ${brewFormulas.mkString(" ")}",
-      s"""echo "LLVM_BIN=$llvmBase/llvm@$llvmVersion/bin" >> $$GITHUB_ENV""",
-    ),
-    cond = Some(s"(matrix.project == 'rootNative') && matrix.os == '$os'"),
-    name = Some(s"Install native dependencies ($os)"),
-  )
-}
-
-ThisBuild / githubWorkflowBuild := {
-  WorkflowStep.Sbt(
-    List("Test/copyResources; scalafixAll --check; all scalafmtSbtCheck scalafmtCheckAll"),
-    name = Some("Check scalafix/scalafmt lints"),
-    cond = Some(
-      s"matrix.java == '${defaultJavaVersion.render}' && (matrix.scala == '3') && matrix.project == 'rootJVM' && startsWith(matrix.os, 'ubuntu')"
-    ),
-  ) +: (ThisBuild / githubWorkflowBuild).value
-}
-
-// override Test step to run on ubuntu only due to requirement of docker
-ThisBuild / githubWorkflowBuild := {
-  (ThisBuild / githubWorkflowBuild).value.flatMap {
-    case s if s.name.contains("Test") =>
-      List(
-        WorkflowStep.Run(
-          commands = List("docker compose up -d"),
-          name = Some("Start up Postgres"),
-          cond = Some("startsWith(matrix.os, 'ubuntu')"),
-        ),
-        WorkflowStep.Sbt(
-          List("test"),
-          name = Some("Test"),
-          cond = Some("startsWith(matrix.os, 'ubuntu')"),
-        ),
-      )
-    case s => List(s)
-  }
-}
-
-ThisBuild / githubWorkflowBuild += WorkflowStep.Run(
-  commands = List("sbt cliNative/test"),
-  name = Some("CLI test"),
-  cond = Some("matrix.project == 'rootNative' && (matrix.scala == '3')"),
-)
-
-ThisBuild / githubWorkflowBuild ++= List(
-  "ubuntu" -> Map("SCALANATIVE_LTO" -> LTO.thin.toString()),
-  "macos"  -> Map.empty,
-).flatMap { case (os, envs) =>
-  val base = WorkflowStep.Run(
-    commands = List("sbt buildCliBinary"),
-    name = Some(s"Generate CLI native binary"),
-    cond = Some(s"matrix.project == 'rootNative' && (matrix.scala == '3') && startsWith(matrix.os, '$os')"),
-  )
-
-  List(
-    // debug mode
-    base.withName(base.name.map(_ + s" ($os, debug)")).withCond(base.cond.map(_ + s" && !$isTagCond")),
-    // release mode (takes long time...)
-    base
-      .withName(base.name.map(_ + s" ($os, release)"))
-      .withEnv(env = Map("SCALANATIVE_MODE" -> Mode.releaseFast.toString()) ++ envs)
-      .withCond(base.cond.map(_ + s" && $isTagCond")),
-  )
-}
-
-ThisBuild / githubWorkflowBuild += WorkflowStep.Use(
-  ref = UseRef.Public("actions", "upload-artifact", actionUploadArtifactVersion),
-  params = Map("name" -> "cli-bin-${{ matrix.os }}", "path" -> "modules/cli/native/target/bin/*"),
-  name = Some("Upload command line binaries"),
-  cond = Some(s"matrix.project == 'rootNative' && (matrix.scala == '3') && $isTagCond"),
-)
-
-ThisBuild / githubWorkflowGeneratedCI := (ThisBuild / githubWorkflowGeneratedCI).value.flatMap {
-  case j if j.id == "publish" =>
-    List(
-      j,
-      WorkflowJob(
-        id = "publish-cli-bin",
-        name = "Publish command line binaries",
-        needs = List("build"),
-        cond = Some(isTagCond),
-        scalas = Nil,
-        javas = List(defaultJavaVersion),
-        oses = List(defautOs),
-        steps = List(
-          WorkflowStep.Use(
-            ref = UseRef.Public("actions", "download-artifact", actionDownloadArtifactVersion),
-            params = Map("pattern" -> "cli-bin-*", "path" -> "target-cli/bin", "merge-multiple" -> "true"),
-            name = Some("Download command line binaries"),
-          ),
-          WorkflowStep.Use(
-            ref = UseRef.Public("softprops", "action-gh-release", actionGhReleaseVersion),
-            name = Some("Upload release binaries"),
-            params = Map("files" -> "target-cli/bin/*"),
-          ),
-        ),
-      ),
-      WorkflowJob(
-        id = "publish-cli-docker",
-        name = "Publish command line docker image",
-        needs = List("build"),
-        cond = Some(isTagCond),
-        scalas = Nil,
-        javas = List(defaultJavaVersion),
-        oses = List(defautOs),
-        steps = List(
-          WorkflowStep.Checkout,
-          WorkflowStep.Use(
-            name = Some("Download command line linux build"),
-            ref = UseRef.Public("actions", "download-artifact", actionDownloadArtifactVersion),
-            params = Map("name" -> "target-${{ matrix.os }}-${{ matrix.java }}-3-rootNative"),
-          ),
-          WorkflowStep.Run(
-            name = Some("Inflate command line linux build"),
-            commands = List("tar xf targets.tar", "rm targets.tar"),
-          ),
-          WorkflowStep.Run(
-            name = Some("Release docker image"),
-            commands = List(
-              """echo -n "${DOCKER_PASSWORD}" | docker login docker.io -u rolang --password-stdin""",
-              "export RELEASE_TAG=${GITHUB_REF_NAME#'v'}",
-              "cp -r modules/cli/native/target/bin docker-build/bin",
-              "docker build ./docker-build -t rolang/dumbo:${RELEASE_TAG}-alpine",
-              "docker run rolang/dumbo:${RELEASE_TAG}-alpine", // run for health-checking the docker image
-              "docker tag rolang/dumbo:${RELEASE_TAG}-alpine rolang/dumbo:latest-alpine",
-              "docker push rolang/dumbo:${RELEASE_TAG}-alpine",
-              "docker push rolang/dumbo:latest-alpine",
-            ),
-            env = Map(
-              "DOCKER_PASSWORD" -> "${{ secrets.DOCKER_PASSWORD }}"
-            ),
-          ),
-        ),
-      ),
-    )
-  case j => List(j)
-}
-
-ThisBuild / githubWorkflowBuild += WorkflowStep.Sbt(
-  List("example/runMain ExampleApp"),
-  name = Some("Run example (covers reading resources from a jar at runtime)"),
-  cond = Some("matrix.project == 'rootJVM' && matrix.scala == '3'"),
-)
-
-ThisBuild / githubWorkflowBuild += WorkflowStep.Run(
-  commands = List("sbt -Dsample_lib_test 'testLib/clean; sampleLib/publishLocal; testLib/run'"),
-  name = Some("Test reading resources from a jar at compile time"),
-  cond = Some("matrix.project == 'rootJVM' && matrix.scala == '3'"),
-)
+semanticdbEnabled := true
+semanticdbVersion := scalafixSemanticdb.revision
 
 addCommandAlias("fix", "; +Test/copyResources; +scalafixAll; +scalafmtAll; scalafmtSbt")
 addCommandAlias("check", "; +Test/copyResources; +scalafixAll --check; +scalafmtCheckAll; scalafmtSbtCheck")
 
-lazy val commonSettings = List(
-  // Headers
+lazy val commonSettings = Seq(
   headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment),
-  headerLicense  := Some(
+  headerLicense := Some(
     HeaderLicense.Custom(
       """|Copyright (c) 2023 by Roman Langolf
          |This software is licensed under the MIT License (MIT).
@@ -247,10 +52,64 @@ lazy val commonSettings = List(
   },
 )
 
-lazy val root = tlCrossRootProject
-  .settings(name := "dumbo")
-  .aggregate(core, tests, testsFlyway)
-  .settings(commonSettings)
+// source directory configuration for cross-project modules (shared + platform-specific dirs)
+def scalaVerDir(binVer: String): String =
+  if (binVer.startsWith("2")) "scala-2" else s"scala-$binVer"
+
+def crossSourceDirSettings(matrixBase: File): Seq[Setting[_]] = Seq(
+  Compile / unmanagedSourceDirectories := {
+    val binVer = scalaBinaryVersion.value
+    Seq(
+      matrixBase / "shared" / "src" / "main" / "scala",
+      matrixBase / "shared" / "src" / "main" / scalaVerDir(binVer),
+    ).filter(_.exists).map(_.getCanonicalFile)
+  },
+  Test / unmanagedSourceDirectories := {
+    val binVer = scalaBinaryVersion.value
+    Seq(
+      matrixBase / "shared" / "src" / "test" / "scala",
+      matrixBase / "shared" / "src" / "test" / scalaVerDir(binVer),
+    ).filter(_.exists).map(_.getCanonicalFile)
+  },
+  Test / unmanagedResourceDirectories ++= {
+    Seq(matrixBase / "shared" / "src" / "test" / "resources").filter(_.exists).map(_.getCanonicalFile)
+  },
+)
+
+def jvmSourceDirSettings(matrixBase: File): Seq[Setting[_]] = Seq(
+  Compile / unmanagedSourceDirectories ++= {
+    val binVer = scalaBinaryVersion.value
+    Seq(
+      matrixBase / "jvm" / "src" / "main" / "scala",
+      matrixBase / "jvm" / "src" / "main" / scalaVerDir(binVer),
+    ).filter(_.exists).map(_.getCanonicalFile)
+  },
+  Test / unmanagedSourceDirectories ++= {
+    val binVer = scalaBinaryVersion.value
+    Seq(
+      matrixBase / "jvm" / "src" / "test" / "scala",
+      matrixBase / "jvm" / "src" / "test" / scalaVerDir(binVer),
+    ).filter(_.exists).map(_.getCanonicalFile)
+  },
+  Compile / unmanagedResourceDirectories ++= {
+    Seq(matrixBase / "jvm" / "src" / "main" / "resources").filter(_.exists).map(_.getCanonicalFile)
+  },
+)
+
+def nativeSourceDirSettings(matrixBase: File): Seq[Setting[_]] = Seq(
+  Compile / unmanagedSourceDirectories ++= {
+    Seq(matrixBase / "native" / "src" / "main" / "scala").filter(_.exists).map(_.getCanonicalFile)
+  },
+  Test / unmanagedSourceDirectories ++= {
+    Seq(matrixBase / "native" / "src" / "test" / "scala").filter(_.exists).map(_.getCanonicalFile)
+  },
+)
+
+lazy val root = project.in(file("."))
+  .settings(
+    name := "dumbo-root",
+    publish / skip := true,
+  )
 
 lazy val skunkVersion = "1.0.0"
 
@@ -258,52 +117,68 @@ lazy val munitVersion = "1.3.3"
 
 lazy val munitCEVersion = "2.2.0"
 
-lazy val core = crossProject(JVMPlatform, NativePlatform)
-  .crossType(CrossType.Full)
+lazy val coreBase = file("modules/core")
+
+lazy val core = (projectMatrix in coreBase)
   .enablePlugins(AutomateHeaderPlugin, BuildInfoPlugin)
-  .in(file("modules/core"))
+  .settings(commonSettings*)
+  .settings(crossSourceDirSettings(coreBase)*)
   .settings(
     name := "dumbo",
     libraryDependencies ++= Seq(
-      "org.tpolecat" %%% "skunk-core" % skunkVersion
+      "org.tpolecat" %% "skunk-core" % skunkVersion
     ),
     buildInfoPackage := "dumbo",
-    buildInfoKeys    := {
-      val isNative = crossProjectPlatform.value.identifier == "native"
-      Seq[BuildInfoKey](
-        version,
-        scalaVersion,
-        scalaBinaryVersion,
-      ) ++ (if (isNative) Seq(BuildInfoKey("scalaNativeVersion" -> nativeVersion)) else Seq())
-    },
+    buildInfoKeys := Seq[BuildInfoKey](version, scalaVersion, scalaBinaryVersion),
   )
-  .settings(commonSettings)
-  .nativeSettings(
-    scalaVersion       := `scala-3`,
-    crossScalaVersions := Seq(`scala-3`),
+  .jvmPlatform(
+    scalaVersions = Seq(`scala-3`, `scala-2.13`),
+    settings = jvmSourceDirSettings(coreBase),
   )
-
-lazy val cli = crossProject(NativePlatform)
-  .crossType(CrossType.Full)
-  .enablePlugins(AutomateHeaderPlugin)
-  .in(file("modules/cli"))
-  .dependsOn(core)
-  .settings(
-    scalaVersion := `scala-3`,
-    name         := "dumbo-cli",
-    libraryDependencies ++= Seq(
-      "org.scalameta" %%% "munit" % munitVersion % Test
+  .nativePlatform(
+    scalaVersions = Seq(`scala-3`),
+    settings = nativeSourceDirSettings(coreBase) ++ Seq[Setting[_]](
+      buildInfoKeys ++= Seq[BuildInfoKey]("scalaNativeVersion" -> nativeVersion),
     ),
   )
-  .settings(commonSettings)
-  .nativeEnablePlugins(ScalaNativeBrewedConfigPlugin)
-  .nativeSettings(
-    nativeBrewFormulas ++= brewFormulas
+
+lazy val coreJVM3    = LocalProject("core")
+lazy val coreJVM2_13 = LocalProject("core2_13")
+lazy val coreNative3 = LocalProject("coreNative")
+
+lazy val llvmVersion  = "22"
+lazy val brewFormulas = Set("s2n", "utf8proc")
+
+lazy val cliBase = file("modules/cli")
+
+lazy val cli = (projectMatrix in cliBase)
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(core)
+  .settings(commonSettings*)
+  .settings(crossSourceDirSettings(cliBase)*)
+  .settings(
+    name := "dumbo-cli",
+    libraryDependencies ++= Seq(
+      "org.scalameta" %% "munit" % munitVersion % Test
+    ),
+  )
+  .nativePlatform(
+    scalaVersions = Seq(`scala-3`),
+    settings = nativeSourceDirSettings(cliBase) ++ Seq[Setting[_]](
+      nativeConfig ~= { c =>
+        brewFormulas.foldLeft(c) { (cfg, formula) =>
+          cfg
+            .withLinkingOptions(cfg.linkingOptions :+ s"-L${System.getProperty(s"user.home")}/.linuxbrew/opt/$formula/lib")
+            .withCompileOptions(cfg.compileOptions :+ s"-I${System.getProperty(s"user.home")}/.linuxbrew/opt/$formula/include")
+        }
+      },
+    ),
   )
 
-lazy val cliNative      = cli.native
+lazy val cliNative = cli.native(`scala-3`)
+
 lazy val buildCliBinary = taskKey[File]("")
-buildCliBinary := {
+buildCliBinary := Def.uncached {
   def normalise(s: String) = s.toLowerCase.replaceAll("[^a-z0-9]+", "")
   val props                = sys.props.toMap
   val os                   = normalise(props.getOrElse("os.name", "")) match {
@@ -322,32 +197,35 @@ buildCliBinary := {
     case _                                         => "unknown"
   }
 
-  val name    = s"dumbo-cli-$arch-$os"
-  val built   = (cliNative / Compile / nativeLink).value
-  val destBin = (cliNative / target).value / "bin" / name
-  val destZip = (cliNative / target).value / "bin" / s"$name.zip"
+  val name      = s"dumbo-cli-$arch-$os"
+  val built     = (cliNative / Compile / nativeLink).value
+  val converter = fileConverter.value
+  val builtFile = converter.toPath(built).toFile
+  val destBin   = (cliNative / target).value / "bin" / name
+  val destZip   = (cliNative / target).value / "bin" / s"$name.zip"
 
-  IO.copyFile(built, destBin)
+  IO.copyFile(builtFile, destBin)
   sLog.value.info(s"Built cli binary in $destBin")
 
-  IO.zip(Seq((built, "dumbo")), destZip, None)
+  IO.zip(Seq((builtFile, "dumbo")), destZip, None)
   sLog.value.info(s"Built cli binary zip in $destZip")
 
   destBin
 }
 
-lazy val tests = crossProject(JVMPlatform, NativePlatform)
-  .crossType(CrossType.Full)
-  .enablePlugins(AutomateHeaderPlugin, NoPublishPlugin)
-  .in(file("modules/tests"))
+lazy val testsBase = file("modules/tests")
+
+lazy val tests = (projectMatrix in testsBase)
+  .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(core)
-  .settings(commonSettings)
+  .settings(commonSettings*)
+  .settings(crossSourceDirSettings(testsBase)*)
   .settings(
     publish / skip := true,
     Test / scalacOptions -= "-Werror",
     libraryDependencies ++= Seq(
-      "org.scalameta" %%% "munit"             % munitVersion   % Test,
-      "org.typelevel" %%% "munit-cats-effect" % munitCEVersion % Test,
+      "org.scalameta" %% "munit"             % munitVersion   % Test,
+      "org.typelevel" %% "munit-cats-effect" % munitCEVersion % Test,
     ),
     testFrameworks += new TestFramework("munit.Framework"),
     testOptions += {
@@ -356,20 +234,27 @@ lazy val tests = crossProject(JVMPlatform, NativePlatform)
       } else Tests.Argument()
     },
   )
-  .nativeEnablePlugins(ScalaNativeBrewedConfigPlugin)
-  .nativeSettings(
-    scalaVersion       := `scala-3`,
-    crossScalaVersions := Seq(`scala-3`),
-    Test / nativeBrewFormulas ++= brewFormulas,
-    Test / envVars ++= Map("S2N_DONT_MLOCK" -> "1"),
-    Test / testOptions ++= {
-      if (sys.env.contains("CI")) Seq(Tests.Argument(TestFrameworks.MUnit, "--exclude-tags=CockroachDbTest"))
-      else Seq.empty
-    },
-    nativeConfig ~= {
-      _.withEmbedResources(true)
-    },
+  .jvmPlatform(
+    scalaVersions = Seq(`scala-3`, `scala-2.13`),
+    settings = jvmSourceDirSettings(testsBase),
   )
+  .nativePlatform(
+    scalaVersions = Seq(`scala-3`),
+    settings = nativeSourceDirSettings(testsBase) ++ Seq[Setting[_]](
+      Test / envVars ++= Map("S2N_DONT_MLOCK" -> "1"),
+      Test / testOptions ++= {
+        if (sys.env.contains("CI")) Seq(Tests.Argument(TestFrameworks.MUnit, "--exclude-tags=CockroachDbTest"))
+        else Seq.empty
+      },
+      nativeConfig ~= {
+        _.withEmbedResources(true)
+      },
+    ),
+  )
+
+lazy val testsJVM3    = tests.jvm(`scala-3`)
+lazy val testsJVM2_13 = tests.jvm(`scala-2.13`)
+lazy val testsNative3 = tests.native(`scala-3`)
 
 lazy val flywayVersion = "12.9.0"
 
@@ -377,9 +262,9 @@ lazy val postgresqlVersion = "42.7.11"
 
 lazy val testsFlyway = project
   .in(file("modules/tests-flyway"))
-  .enablePlugins(AutomateHeaderPlugin, NoPublishPlugin)
-  .dependsOn(core.jvm, tests.jvm % "compile->compile;test->test")
-  .settings(commonSettings)
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(LocalProject("core"), LocalProject("tests") % "compile->compile;test->test")
+  .settings(commonSettings*)
   .settings(
     publish / skip := true,
     Test / scalacOptions -= "-Werror",
@@ -393,9 +278,8 @@ lazy val testsFlyway = project
 
 lazy val example = project
   .in(file("modules/example"))
-  .enablePlugins(NoPublishPlugin)
-  .dependsOn(core.jvm)
-  .settings(commonSettings)
+  .dependsOn(LocalProject("core"))
+  .settings(commonSettings*)
   .settings(
     scalaVersion          := `scala-3-latest`,
     crossScalaVersions    := Seq(`scala-3-latest`),
@@ -410,7 +294,6 @@ lazy val example = project
 
 lazy val sampleLib = project
   .in(file("modules/sample-lib"))
-  .enablePlugins((if (!sys.props.contains("sample_lib_test")) Seq(NoPublishPlugin) else Nil) *)
   .settings(
     version               := "0.0.1-SNAPSHOT",
     scalaVersion          := `scala-3`,
@@ -421,9 +304,9 @@ lazy val sampleLib = project
 
 lazy val testLib = project
   .in(file("modules/test-lib"))
-  .enablePlugins(NoPublishPlugin)
-  .settings(commonSettings)
-  .dependsOn(core.jvm)
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(LocalProject("core"))
+  .settings(commonSettings*)
   .settings(
     Compile / run / fork                := true,
     libraryDependencies += "dev.rolang" %% "sample-lib" % "0.0.1-SNAPSHOT",
@@ -437,7 +320,7 @@ lazy val generateReadme =
   taskKey[Unit]("Generate README.md from docs/README.md replacing @VERSION@ and @EXAMPLE(<path>) placeholders")
 
 generateReadme := {
-  import scala.sys.process._
+  import scala.sys.process.*
   import scala.util.matching.Regex
 
   val latestTag = "git tag -l --sort=-v:refname".!!.linesIterator

--- a/modules/test-lib/src/main/scala/TestLib.scala
+++ b/modules/test-lib/src/main/scala/TestLib.scala
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 by Roman Langolf
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
 import dumbo.ResourceFilePath
 
 @main def run(args: String*) =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.12
+sbt.version=2.0.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,16 +2,8 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
 
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
 
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.7")
 
-lazy val sbtTlVersion = "0.8.6"
-
-addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % sbtTlVersion)
-
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % sbtTlVersion)
-
-addSbtPlugin("com.armanbilge" % "sbt-scala-native-config-brew" % "0.4.0")
+addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")


### PR DESCRIPTION
## Summary

Update the sbt build definition to sbt 2.0.0 (released 2026-06-14). The plugin ecosystem for sbt 2.x uses the `_sbt2_3` artifact suffix.

### Changes

- `project/build.properties`: sbt.version=2.0.0
- `project/plugins.sbt`: keep only plugins published for `_sbt2_3`
  - sbt-scalafmt, sbt-scala-native, sbt-scalafix, sbt-header, sbt-buildinfo
  - Dropped: sbt-typelevel, sbt-crossproject, sbt-dependency-updates (no `_sbt2_3` artifact)
- `build.sbt`: fully rewritten
  - `projectMatrix` replaces `crossProject` for shared/JVM/Native layout
  - Bare settings as common settings (sbt 2.x default)
  - `Def.uncached` on `buildCliBinary` (sbt 2.x caches all tasks)
  - `fileConverter` for `HashedVirtualFileRef` -> `File` conversion
  - `LocalProject` references for regular projects depending on projectMatrix sub-projects
  - Explicit `scalaVerDir` helper mapping `2.13` -> `scala-2` to match existing source layout

### Notes

- `sbt-metals` and `sbt-debug-adapter` are auto-generated; sbt-debug-adapter commented out (no `_sbt2_3`)
- `sbt-jdi-tools` commented out in meta-build (no `_sbt2_3`)
- CI config was previously auto-generated by sbt-typelevel and needs manual replacement

## Test plan

- [x] `core/compile` (Scala 3 JVM)
- [x] `core2_13/compile` (Scala 2.13 JVM)
- [x] `coreNative/compile` (Scala 3 Native)
- [x] `cliNative/compile`
- [x] `tests/compile`, `tests2_13/compile`, `testsNative/compile`
- [x] `sampleLib/compile`
- [ ] `tests/test`, `testsNative/test`, etc. (requires running DB / full CI setup)
- [ ] `example/compile` (pre-existing macro resource path issue, not related to sbt 2.x)