### PR TITLE
Preserve exec bit in CLI zip; document installation via mise

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,25 @@ curl -L https://github.com/rolang/dumbo/releases/latest/download/dumbo-cli-aarch
 ./dumbo -v
 ```
 
+#### mise
+
+[mise](https://mise.jdx.dev/) can install and manage the dumbo command line across Linux (x86_64 / aarch64) and macOS (arm64) using the [GitHub backend](https://mise.jdx.dev/dev-tools/backends/github.html), which downloads the release asset matching your platform.
+
+Install the latest release globally:
+
+```shell
+mise use -g github:rolang/dumbo@latest
+```
+
+Or pin a version per project by adding the following to your `mise.toml`:
+
+```toml
+[tools."github:rolang/dumbo"]
+version = "latest"
+```
+
+The native dependencies ([utf8proc](https://github.com/JuliaStrings/utf8proc) and [s2n-tls](https://github.com/aws/s2n-tls)) are still required (see the Linux and macOS sections above); mise only fetches the dumbo binary.
+
 #### Docker
 
 A docker image with the command line is published to docker hub: [rolang/dumbo](https://hub.docker.com/r/rolang/dumbo).

--- a/build.sbt
+++ b/build.sbt
@@ -330,7 +330,17 @@ buildCliBinary := {
   IO.copyFile(built, destBin)
   sLog.value.info(s"Built cli binary in $destBin")
 
-  IO.zip(Seq((built, "dumbo")), destZip, None)
+  // sbt's IO.zip uses java.util.zip which does not store Unix mode bits, so
+  // the executable bit was lost in the archive and tools like mise extracted
+  // it as 0644. Shell out to the `zip` CLI, which records the file's mode in
+  // the entry's external attributes, so `unzip`/mise restore the exec bit.
+  val staged = (cliNative / target).value / "bin" / "dumbo"
+  IO.copyFile(built, staged)
+  scala.sys.process.Process(Seq("chmod", "+x", staged.getAbsolutePath)).!
+  scala.sys.process
+    .Process(Seq("zip", "-X", "-j", destZip.getAbsolutePath, staged.getAbsolutePath), staged.getParentFile)
+    .!
+  IO.delete(staged)
   sLog.value.info(s"Built cli binary zip in $destZip")
 
   destBin

--- a/docs/README.md
+++ b/docs/README.md
@@ -318,6 +318,25 @@ curl -L https://github.com/rolang/dumbo/releases/latest/download/dumbo-cli-aarch
 ./dumbo -v
 ```
 
+#### mise
+
+[mise](https://mise.jdx.dev/) can install and manage the dumbo command line across Linux (x86_64 / aarch64) and macOS (arm64) using the [GitHub backend](https://mise.jdx.dev/dev-tools/backends/github.html), which downloads the release asset matching your platform.
+
+Install the latest release globally:
+
+```shell
+mise use -g github:rolang/dumbo@latest
+```
+
+Or pin a version per project by adding the following to your `mise.toml`:
+
+```toml
+[tools."github:rolang/dumbo"]
+version = "latest"
+```
+
+The native dependencies ([utf8proc](https://github.com/JuliaStrings/utf8proc) and [s2n-tls](https://github.com/aws/s2n-tls)) are still required (see the Linux and macOS sections above); mise only fetches the dumbo binary.
+
 #### Docker
 
 A docker image with the command line is published to docker hub: [rolang/dumbo](https://hub.docker.com/r/rolang/dumbo).


### PR DESCRIPTION
## Summary

- Keep producing the zipped CLI release asset, but fix `buildCliBinary` so the executable bit survives in the archive. `sbt.IO.zip` (via `java.util.zip.ZipOutputStream`) does not store Unix mode bits in the entry's external attributes, so the binary extracted as `0644` and mise produced `Permission denied` on run. Replace it with a call to the `zip` CLI (`zip -X -j`), which records the file mode in the entry's external attributes, so `unzip`/mise restore `0755` after extraction. The `zip` and `chmod` commands are available on the ubuntu and macOS runners used by CI.
- Add a `#### mise` subsection to `README.md` and `docs/README.md` under the command-line install instructions, showing `mise use -g github:rolang/dumbo@latest` (or the `mise.toml` config).

## Test plan

- [ ] On a tag push, the `Generate CLI native binary (release)` step produces `modules/cli/native/target/bin/dumbo-cli-<arch>-<os>.zip` whose `dumbo` entry shows `-rwxr-xr-x` via `unzip -ZT`.
- [ ] After the next tag is cut, `mise use -g github:rolang/dumbo@<tag>` installs and `dumbo --version` runs without `chmod`.
- [ ] Manual unzip of the published asset on Linux and macOS yields an executable `dumbo` binary.
- [ ] Existing ≤0.10.1 releases still require the user-side `rename_exe = "dumbo"` workaround; they are not affected by this change.